### PR TITLE
Fix for Bug#76.  Add check for version issues and extra option for creating project files.

### DIFF
--- a/map2loop/m2l_export.py
+++ b/map2loop/m2l_export.py
@@ -1663,6 +1663,7 @@ def export_to_projectfile(loopFilename, tmp_path, output_path, bbox, proj_crs, o
                     resp = LoopProjectFile.Get(loopFilename,'extents')
                     if not resp['errorFlag']:
                         existingExtents = resp['value']
+                    os.remove(loopFilename)
                 else:
                     print("(ERROR) LoopProjectFile version mismatch, export to loop project file aborted")
                     return


### PR DESCRIPTION
Added needed check to ensure project file and current module version match.  This prevents an issue where an attempt to add a newer data structure to an older version causes a data structure mismatch exception.

Also added an overwrite option for export_to_projectfile so that if a version mismatch is present the old file will be removed and then recreated. 